### PR TITLE
Updated condition check of stack from stack.size() to stack.isEmpty()

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/MapUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/MapUtils.java
@@ -99,7 +99,7 @@ public class MapUtils {
 
         if (n > 2) {
             stack.push(new int[]{0, (n - 1)});
-            while (stack.size() > 0) {
+            while (!stack.isEmpty()) {
                 current = stack.pop();
                 maxDist = 0;
                 for (idx = current[0] + 1; idx < current[1]; ++idx) {

--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/TrackPointsDebug.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/TrackPointsDebug.java
@@ -5,7 +5,7 @@ public class TrackPointsDebug {
     public int trackpointsInvalid = 0;
     public int trackpointsDrawn = 0;
     public int trackpointsPause = 0;
-    public int segments = 0;
+    public static int segments = 0;
 
     public void add(final TrackPointsDebug other) {
         this.trackpointsReceived += other.trackpointsReceived;

--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/TrackPointsDebug.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/TrackPointsDebug.java
@@ -5,7 +5,7 @@ public class TrackPointsDebug {
     public int trackpointsInvalid = 0;
     public int trackpointsDrawn = 0;
     public int trackpointsPause = 0;
-    public static int segments = 0;
+    public int segments = 0;
 
     public void add(final TrackPointsDebug other) {
         this.trackpointsReceived += other.trackpointsReceived;


### PR DESCRIPTION
src/main/java/de/storchp/opentracks/osmplugin/utils/TrackPointsDebug.java

Issue:
"Collection.isEmpty()" should be used to test for emptiness

Solution:
**`while (stack.size() > 0)`** can be replaced with the  **`while (!stack.isEmpty())`**.