### PR TITLE
Technical Debt: Refactored stack size check to use stack isEmpty for code readability

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/MapUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/MapUtils.java
@@ -99,7 +99,7 @@ public class MapUtils {
 
         if (n > 2) {
             stack.push(new int[]{0, (n - 1)});
-            while (stack.size() > 0) {
+            while (!stack.isEmpty()) {
                 current = stack.pop();
                 maxDist = 0;
                 for (idx = current[0] + 1; idx < current[1]; ++idx) {


### PR DESCRIPTION
Refactored stack size check to use **!stack.isEmpty()** for code readability and maintainability. Issue: #7


<img width="1123" alt="image" src="https://github.com/SnehilSharma0308/OSMDashboard-Winter-2024-SOEN-6431-fork/assets/145623803/428e3574-594b-4008-a4fc-d7b2bd700d9a">
