### PR TITLE
Reorder the modifiers to comply with the Java Language Specification

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java
@@ -19,7 +19,7 @@ import de.storchp.opentracks.osmplugin.R;
 
 public class PreferencesUtils {
 
-    private final static String TAG = PreferencesUtils.class.getSimpleName();
+    private static final String TAG = PreferencesUtils.class.getSimpleName();
     private static SharedPreferences sharedPrefs;
     private static Resources resources;
 


### PR DESCRIPTION
src/main/java/de/storchp/opentracks/osmplugin/utils/PreferencesUtils.java

Problem:
The Java Language Specification recommends listing modifiers in the following order:

1. Annotations
2. public
3. protected
4. private
5. abstract
6. static
7. final
8. transient
9. volatile
10. synchronized
11. native
12. default
13. strictfp

However, in the PreferencesUtils.java file, there is line 22: **private final static StringTAG=PreferencesUtils.class.getSimpleName();** The order of modifiers in this case is improper since it has no technical consequence, but it reduces code readability because most developers are used to the standard order.

Solution:
instead of writing **private final static** we can change to **private static final** so, it maintain the order as mention in Java Language Specification.